### PR TITLE
Fixes to docksal build process

### DIFF
--- a/.docksal/commands/build-forloeb
+++ b/.docksal/commands/build-forloeb
@@ -19,6 +19,12 @@ echo-green () { echo -e "${green}$1${NC}"; }
 echo-green-bg () { echo -e "${green_bg}$1${NC}"; }
 echo-yellow () { echo -e "${yellow}$1${NC}"; }
 
+echo-yellow "Updating os2forms_forloeb module"
+fin composer update os2forms/os2forms_forloeb
+
+echo-yellow "Updating composer.lock file"
+fin composer update --lock
+
 echo-yellow "Fetching composer dependencies"
 fin composer install
 

--- a/composer.lock
+++ b/composer.lock
@@ -4873,6 +4873,65 @@
             }
         },
         {
+            "name": "drupal/dynamic_entity_reference",
+            "version": "2.0.0-alpha14",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/dynamic_entity_reference.git",
+                "reference": "8.x-2.0-alpha14"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/dynamic_entity_reference-8.x-2.0-alpha14.zip",
+                "reference": "8.x-2.0-alpha14",
+                "shasum": "7fc9f39fa9e81f87c66f98399420bb3f6dbafc79"
+            },
+            "require": {
+                "drupal/core": "^8.7.7 || ^9"
+            },
+            "require-dev": {
+                "drupal/diff": "1.x-dev"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-2.0-alpha14",
+                    "datestamp": "1603517207",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Alpha releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Lee Rowlands",
+                    "homepage": "https://www.drupal.org/u/larowlan",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Jibran Ijaz",
+                    "homepage": "https://www.drupal.org/u/jibran",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "larowlan",
+                    "homepage": "https://www.drupal.org/user/395439"
+                }
+            ],
+            "description": "Provides a field that allows an entity-reference field to reference more than one entity type.",
+            "homepage": "http://drupal.org/project/dynamic_entity_reference",
+            "support": {
+                "source": "http://cgit.drupalcode.org/dynamic_entity_reference",
+                "issues": "http://drupal.org/project/dynamic_entity_reference",
+                "irc": "irc://irc.freenode.org/drupal-contribute"
+            }
+        },
+        {
             "name": "drupal/easy_breadcrumb",
             "version": "1.13.0",
             "source": {
@@ -9358,6 +9417,58 @@
             }
         },
         {
+            "name": "drupal/workflow_participants",
+            "version": "dev-2.x",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/workflow_participants.git",
+                "reference": "9ac2f8e97eb339df81d45bf2090f4e84285e957a"
+            },
+            "require": {
+                "drupal/core": "^8",
+                "drupal/dynamic_entity_reference": "^2.0"
+            },
+            "require-dev": {
+                "drupal/content_moderation_notifications": "^3.0",
+                "drupal/diff": "^1.0",
+                "drupal/token": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-2.4+7-dev",
+                    "datestamp": "1569622687",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Dev releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "jhedstrom",
+                    "homepage": "https://www.drupal.org/user/208732"
+                }
+            ],
+            "description": "Allows for per-entity workflow participants (editors and reviewers) to be assigned.",
+            "homepage": "https://www.drupal.org/project/workflow_participants",
+            "keywords": [
+                "Drupal"
+            ],
+            "support": {
+                "source": "http://cgit.drupalcode.org/workflow_participants",
+                "issues": "https://www.drupal.org/project/issues/workflow_participants"
+            },
+            "time": "2019-09-27T22:16:11+00:00"
+        },
+        {
             "name": "drupol/phposinfo",
             "version": "1.6.5",
             "source": {
@@ -11424,12 +11535,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/OS2Forms/os2forms_forloeb.git",
-                "reference": "cdef2c6a7e220176dc972ed15185414c1ccd6de2"
+                "reference": "9c6c9acbd982a723ecf836637d4b4a600d0b82f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OS2Forms/os2forms_forloeb/zipball/cdef2c6a7e220176dc972ed15185414c1ccd6de2",
-                "reference": "cdef2c6a7e220176dc972ed15185414c1ccd6de2",
+                "url": "https://api.github.com/repos/OS2Forms/os2forms_forloeb/zipball/9c6c9acbd982a723ecf836637d4b4a600d0b82f1",
+                "reference": "9c6c9acbd982a723ecf836637d4b4a600d0b82f1",
                 "shasum": ""
             },
             "require": {
@@ -11468,6 +11579,7 @@
                 "drupal/webform_rest": "4.0.0-beta2",
                 "drupal/webform_scheduled_tasks": "^2.0",
                 "drupal/webform_views": "5.0.0-alpha7",
+                "drupal/workflow_participants": "^2.4",
                 "vlucas/phpdotenv": "^2.4",
                 "webmozart/path-util": "2.3.0",
                 "zaporylie/composer-drupal-optimizations": "1.2.0"
@@ -11496,7 +11608,7 @@
                 "EUPL-1.2"
             ],
             "description": "This module adds Maestro workflow engine and functionality to produce advanced workflows",
-            "time": "2021-03-22T15:51:11+00:00"
+            "time": "2021-03-24T13:22:19+00:00"
         },
         {
             "name": "os2web/os2web_datalookup",
@@ -18429,5 +18541,6 @@
     "platform": {
         "php": ">=7.1"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
As it turns out, a  `composer update --lock` is necessary for the build process to succeed every time.