### PR TITLE
Feature/40227 fix permission

### DIFF
--- a/web/profiles/custom/os2forms_forloeb_profile/config/install/user.role.sagsbehandler.yml
+++ b/web/profiles/custom/os2forms_forloeb_profile/config/install/user.role.sagsbehandler.yml
@@ -50,3 +50,4 @@ permissions:
   - 'view the administration theme'
   - 'view webform submissions any node'
   - 'view webform submissions own node'
+  - 'administer maestro templates'


### PR DESCRIPTION
Add the proper permission to allow people with the "sagsbehandler" role to access traces for tasks.