### PR TITLE
Upgrading dokcsal cli image and setting default composer version

### DIFF
--- a/.docksal/docksal.env
+++ b/.docksal/docksal.env
@@ -1,3 +1,4 @@
 DOCKSAL_STACK=default
 DOCROOT=web
-CLI_IMAGE="docksal/cli:2.11-php7.4"
+CLI_IMAGE="docksal/cli:2.13-php7.4"
+COMPOSER_DEFAULT_VERSION="2"


### PR DESCRIPTION
The composer.lock file already present in this project has the "plugin-api-version" attribute set to 2.0.0 which means that it was updated/created with version 2 of composer. This PR is just for having the docksal configuration use version 2 of composer as well.